### PR TITLE
Add 'module' and 'browser' fields

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -27,6 +27,8 @@ module.exports = Object.freeze({
      * Configuration
      */
     'main',
+    'module',
+    'browser',
     'man',
     'preferGlobal',
     'bin',

--- a/tests/__fixtures__/package-1.json
+++ b/tests/__fixtures__/package-1.json
@@ -5,6 +5,8 @@
   "version": "1.0.1",
   "author": "Cameron Hunter <hello@cameronhunter.co.uk>",
   "main": "src/index.js",
+  "module": "src/index.mjs",
+  "browser": "src/index.browser.js",
   "bin": {
     "prettier-package-json": "./bin/prettier-package-json"
   },

--- a/tests/__fixtures__/package-2.json
+++ b/tests/__fixtures__/package-2.json
@@ -5,6 +5,8 @@
   "license": "MIT",
   "version": "1.0.1",
   "main": "src/index.js",
+  "module": "src/index.mjs",
+  "browser": "src/index.browser.js",
   "bin": {
     "prettier-package-json": "./bin/prettier-package-json"
   },

--- a/tests/__snapshots__/command-line.test.js.snap
+++ b/tests/__snapshots__/command-line.test.js.snap
@@ -21,6 +21,8 @@ Object {
         \\"author\\": \\"Cameron Hunter <hello@cameronhunter.co.uk>\\",
         \\"version\\": \\"1.0.1\\",
         \\"main\\": \\"src/index.js\\",
+        \\"module\\": \\"src/index.mjs\\",
+        \\"browser\\": \\"src/index.browser.js\\",
         \\"bin\\": {
                 \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
         },
@@ -66,6 +68,8 @@ Object {
 	\\"author\\": \\"Cameron Hunter <hello@cameronhunter.co.uk>\\",
 	\\"version\\": \\"1.0.1\\",
 	\\"main\\": \\"src/index.js\\",
+	\\"module\\": \\"src/index.mjs\\",
+	\\"browser\\": \\"src/index.browser.js\\",
 	\\"bin\\": {
 		\\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
 	},
@@ -111,6 +115,8 @@ Object {
   \\"author\\": \\"Cameron Hunter <hello@cameronhunter.co.uk>\\",
   \\"version\\": \\"1.0.1\\",
   \\"main\\": \\"src/index.js\\",
+  \\"module\\": \\"src/index.mjs\\",
+  \\"browser\\": \\"src/index.browser.js\\",
   \\"bin\\": {
     \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
   },
@@ -148,6 +154,8 @@ Object {
   \\"author\\": \\"Cameron Hunter <hello@cameronhunter.co.uk>\\",
   \\"version\\": \\"1.0.1\\",
   \\"main\\": \\"src/index.js\\",
+  \\"module\\": \\"src/index.mjs\\",
+  \\"browser\\": \\"src/index.browser.js\\",
   \\"bin\\": {
     \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
   },
@@ -189,6 +197,8 @@ Object {
   \\"author\\": \\"Cameron Hunter <hello@cameronhunter.co.uk>\\",
   \\"version\\": \\"1.0.1\\",
   \\"main\\": \\"src/index.js\\",
+  \\"module\\": \\"src/index.mjs\\",
+  \\"browser\\": \\"src/index.browser.js\\",
   \\"bin\\": {
     \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
   },


### PR DESCRIPTION
`module` is catching on as the standard way for packages to define an ES6+ module for modern versions of node (ex: index.mjs).
`browser` is used by bundlers like WebPack to import a browser-specific version of a module instead of the value in `main`.