### PR TITLE
Simplify file-reading code

### DIFF
--- a/bin/prettier-package-json
+++ b/bin/prettier-package-json
@@ -62,13 +62,7 @@ function globToPaths(arg) {
 }
 
 function format(filepath, options) {
-  return fs.pathExists(filepath).then((exists) => {
-    if (exists) {
-      return fs.readJson(filepath);
-    } else {
-      return Promise.reject(`${filepath} doesn't exist`);
-    }
-  }).then((json) => {
+  return fs.readJson(filepath).then((json) => {
     return prettier.format(json, options);
   }).then((json) => {
     return { filepath, json };
@@ -78,13 +72,7 @@ function format(filepath, options) {
 }
 
 function check(filepath, options) {
-  return fs.pathExists(filepath).then((exists) => {
-    if (exists) {
-      return fs.readJson(filepath);
-    } else {
-      return Promise.reject(`${filepath} doesn't exist`);
-    }
-  }).then((json) => {
+  return fs.readJson(filepath).then((json) => {
     return prettier.check(json, options);
   }).then((isSame) => {
     return { filepath, isDifferent: !isSame };

--- a/tests/__snapshots__/command-line.test.js.snap
+++ b/tests/__snapshots__/command-line.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`prettier-package-json --list-different tests/__fixtures__/missing.json 1`] = `
+Object {
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
 exports[`prettier-package-json --list-different tests/__fixtures__/package-*.json 1`] = `
 Object {
   "exitCode": 0,

--- a/tests/command-line.test.js
+++ b/tests/command-line.test.js
@@ -24,3 +24,4 @@ testCommand(`prettier-package-json --use-tabs ${fixture('package-1.json')}`);
 testCommand(`prettier-package-json --tab-width 8 ${fixture('package-1.json')}`);
 testCommand(`prettier-package-json ${fixture('package-*.json')}`);
 testCommand(`prettier-package-json --list-different ${fixture('package-*.json')}`);
+testCommand(`prettier-package-json --list-different ${fixture('missing.json')}`);


### PR DESCRIPTION
I am not sure whether this was made on purpose to avoid race conditions, but: `glob` doesn’t match missing files, so in case one adds a missing file, the `files` array will just be empty.

The `else` branch of the `exists` condition is only triggered if the file was removed between globbing and actually fixing / checking it. As this tool should be rather fast I don't think that this a frequent case and this change makes the code a bit more readable.

It's fine to disagree though, as it is just a matter of taste, so you can close the PR if that change doesn't fit your view. 😅 