### PR TITLE
Added `types` and `typings` to Configuration

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -36,6 +36,8 @@ module.exports = Object.freeze({
     'directories',
     'scripts',
     'config',
+    'types',
+    'typings',
 
     /**
      * Dependencies


### PR DESCRIPTION
When using Typescript for the development of an NPM package, a developer may add `types` or `typings` to their package.json so the typescript compiler can identify the correct type declarations for a package.