### PR TITLE
Fix broken markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ These exit codes are only set when in `--list-different` mode.
 | **Tab Width** - Specify the number of spaces per indentation-level. | `2` | `--tab-width <int>` | `tabWidth: <int>` |
 | **Tabs** - Indent lines with tabs instead of spaces. | `false` | `--use-tabs` | `useTabs: <bool>` |
 | **Expand Users** - Expand author and contributors into objects. | `false` | `--expand-users` | `expandUsers: <bool>` |
-| **Key Order** - Specify the order of keys. | See [default options](https://github.com/cameronhunter/prettier-package-json/blob/master/src/defaultOptions.js) | `--key-order <comma,separated,list...>` | `keyOrder: <array|function>` |
+| **Key Order** - Specify the order of keys. | See [default options](https://github.com/cameronhunter/prettier-package-json/blob/master/src/defaultOptions.js) | `--key-order <comma,separated,list...>` | `keyOrder: <array\|function>` |
 
 ## Contributing
 


### PR DESCRIPTION
The pipe character is interpreted as a table cell delimiter and so must be escaped.