### PR TITLE
Include 'sideEffects' in default keyOrder

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -36,6 +36,7 @@ module.exports = Object.freeze({
     'directories',
     'scripts',
     'config',
+    'sideEffects',
     'types',
     'typings',
 


### PR DESCRIPTION
see https://webpack.js.org/guides/tree-shaking/

`sideEffects` can be used to declare that importing a package causes no side effects. This information is used by webpack (and possibly other bundlers) to prune unused files from the tree, reducing overall bundle size.

I’ve added `sideEffects` to the default key order where I think it makes most sense, but your opinion may differ from mine :-).