### PR TITLE
Add $schema and type

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -6,6 +6,7 @@ module.exports = Object.freeze({
     /**
      * Details
      */
+    '$schema',
     'private',
     'name',
     'description',
@@ -17,6 +18,7 @@ module.exports = Object.freeze({
     'repository',
     'bugs',
     'version',
+    'type',
 
     /**
      * Yarn specific


### PR DESCRIPTION
1. Adding in $schema allows text editors without direct support for package.json intellisense and docs to reference a resource like SchemaStore in order to provide those features. It's common practice with JSON Schema to put $schema as the very first field of a JSON file.

Example (package.json):
```json
{
  "$schema": "http://json.schemastore.org/package",
  "name": "foobar"
}
```

2. The type field defines how .js and extensionless files should be treated within a particular package.json file’s package scope. Supported values: "commonjs" (default) or "module".
More info here:
https://nodejs.org/api/esm.html#esm_code_package_json_code_code_type_code_field