### PR TITLE
Update sortFiles function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 yarn-error.log
 /build
+.idea/

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "prettier-package-json": "./bin/prettier-package-json"
   },
   "files": [
-    "bin",
-    "build"
+    "bin/",
+    "build/"
   ],
   "scripts": {
     "build": "tsc",

--- a/src/sort-files.ts
+++ b/src/sort-files.ts
@@ -49,8 +49,26 @@ export default function sortFiles(packageJson: PackageJson): { files?: PackageJs
 
   const isPackageMain = (filepath: string) => filepath === main;
   const ignored = or(ALWAYS_INCLUDED, ALWAYS_EXCLUDED, isPackageMain);
+  const directoriesFirst = (a: string, b: string) => {
+    if (a.endsWith('/') && !b.endsWith('/')) {
+      return -1;
+    } else if (!a.endsWith('/') && b.endsWith('/')) {
+      return 1;
+    } else {
+      return 0;
+    }
+  };
+  const exclusionsLast = (a: string, b: string) => {
+    if (a.startsWith('!') && !b.startsWith('!')) {
+      return 1;
+    } else if (!a.startsWith('!') && b.startsWith('!')) {
+      return -1;
+    } else {
+      return 0;
+    }
+  };
 
-  const sortedAndFilteredFiles = files.filter(not(ignored)).sort();
+  const sortedAndFilteredFiles = files.filter(not(ignored)).sort().sort(directoriesFirst).sort(exclusionsLast);
 
   return sortedAndFilteredFiles.length > 0 ? { files: sortedAndFilteredFiles } : {};
 }

--- a/tests/__fixtures__/package-1.json
+++ b/tests/__fixtures__/package-1.json
@@ -15,9 +15,9 @@
     "test": "jest"
   },
   "files": [
-    "test",
+    "test/",
     "src/index.js",
-    "src",
+    "src/",
     "HISTORY",
     "CHANGELOG.md",
     "readme.md",

--- a/tests/__snapshots__/command-line.test.ts.snap
+++ b/tests/__snapshots__/command-line.test.ts.snap
@@ -24,8 +24,8 @@ Object {
 		\\"jest\\": \\"^20.0.4\\"
 	},
 	\\"files\\": [
-		\\"src\\",
-		\\"test\\"
+		\\"src/\\",
+		\\"test/\\"
 	],
 	\\"keywords\\": [
 		\\"formatter\\",
@@ -82,8 +82,8 @@ Object {
                 \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
         },
         \\"files\\": [
-                \\"src\\",
-                \\"test\\"
+                \\"src/\\",
+                \\"test/\\"
         ],
         \\"scripts\\": {
                 \\"precommit\\": \\"./bin/prettier-package-json --write && git add package.json\\",
@@ -129,8 +129,8 @@ Object {
 		\\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
 	},
 	\\"files\\": [
-		\\"src\\",
-		\\"test\\"
+		\\"src/\\",
+		\\"test/\\"
 	],
 	\\"scripts\\": {
 		\\"precommit\\": \\"./bin/prettier-package-json --write && git add package.json\\",
@@ -176,8 +176,8 @@ Object {
     \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
   },
   \\"files\\": [
-    \\"src\\",
-    \\"test\\"
+    \\"src/\\",
+    \\"test/\\"
   ],
   \\"scripts\\": {
     \\"precommit\\": \\"./bin/prettier-package-json --write && git add package.json\\",
@@ -258,8 +258,8 @@ Object {
     \\"prettier-package-json\\": \\"./bin/prettier-package-json\\"
   },
   \\"files\\": [
-    \\"src\\",
-    \\"test\\"
+    \\"src/\\",
+    \\"test/\\"
   ],
   \\"scripts\\": {
     \\"precommit\\": \\"./bin/prettier-package-json --write && git add package.json\\",

--- a/tests/__snapshots__/sort-files.test.ts.snap
+++ b/tests/__snapshots__/sort-files.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`It orders files in alphabetical order, directories first 1`] = `
+"{
+  \\"files\\": [
+    \\"bin/\\",
+    \\"lib/\\",
+    \\"IMPORTANT.md\\"
+  ]
+}
+"
+`;
+
+exports[`It orders files in alphabetical order, exclusions last 1`] = `
+"{
+  \\"files\\": [
+    \\"bin/\\",
+    \\"lib/\\",
+    \\"!bin/secret.text\\",
+    \\"!lib/**/*.test.js\\"
+  ]
+}
+"
+`;
+
+exports[`It removes always excluded entries from files 1`] = `
+"{
+  \\"files\\": [
+    \\"bin/\\",
+    \\"lib/\\"
+  ]
+}
+"
+`;
+
+exports[`It removes always included entries from files 1`] = `
+"{
+  \\"files\\": [
+    \\"bin/\\",
+    \\"lib/\\"
+  ]
+}
+"
+`;

--- a/tests/sort-files.test.ts
+++ b/tests/sort-files.test.ts
@@ -1,0 +1,52 @@
+import { format } from '../src';
+
+test('It orders files in alphabetical order, directories first', () => {
+  const json = {
+    files: [
+      'IMPORTANT.md',
+      'lib/',
+      'bin/'
+    ]
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});
+
+test('It orders files in alphabetical order, exclusions last', () => {
+  const json = {
+    files: [
+      '!lib/**/*.test.js',
+      'lib/',
+      'bin/',
+      '!bin/secret.text'
+    ]
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});
+
+test('It removes always excluded entries from files', () => {
+  const json = {
+    files: [
+      'bin/',
+      'lib/',
+      'node_modules/',
+      'package-lock.json'
+    ]
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});
+
+test('It removes always included entries from files', () => {
+  const json = {
+    files: [
+      'bin/',
+      'lib/',
+      'package.json',
+      'README.md'
+    ]
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});


### PR DESCRIPTION
A couple of improvements to the way the `files` array is sorted.

It now places exclusions (starting with `!`) _last_ - Otherwise they have no effect. It will also put directories (ending in `/`) _first_, so it better reflects the default `ls` output with `--group-directories-first`.

Fixes #24 

I also added four new test cases for the `sortFiles` function.