### PR TITLE
Add peerDependenciesMeta to the default options

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -50,6 +50,7 @@ module.exports = Object.freeze({
     'bundleDependencies',
     'bundledDependencies',
     'peerDependencies',
+    'peerDependenciesMeta',
     'devDependencies',
 
     /**


### PR DESCRIPTION
When sorting package.json entries it makes sense to put `peerDependenciesMeta` after `peerDependencies`.

The field `peerDependenciesMeta` comes from Yarn and it was implemented NPM: https://github.com/npm/cli/pull/224