### PR TITLE
added prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore test data
+__fixtures__

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  printWidth: 120,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  singleQuote: true,
+  jsxSingleQuote: true,
+  trailingComma: 'none',
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  arrowParens: 'always',
+  proseWrap: 'always',
+  overrides: [
+    {
+      files: '*.md',
+      options: {
+        tabWidth: 2,
+        printWidth: 80
+      }
+    }
+  ]
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "editor.tabSize": 2
+  "editor.tabSize": 2
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ yarn test
 
 Here's what you need to know about the tests:
 
-* The tests uses [Jest](https://facebook.github.io/jest/) snapshots.
-* You can make changes and run `jest -u` (or `yarn test -- -u`) to update the
+- The tests uses [Jest](https://facebook.github.io/jest/) snapshots.
+- You can make changes and run `jest -u` (or `yarn test -- -u`) to update the
   snapshots. Then run `git diff` to take a look at what changed. Always update
   the snapshots when opening a PR.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Prettier `package.json`
 
-[![CI](https://github.com/cameronhunter/prettier-package-json/actions/workflows/ci.yml/badge.svg)](https://github.com/cameronhunter/prettier-package-json/actions/workflows/ci.yml) [![npm](https://img.shields.io/npm/v/prettier-package-json.svg)](https://www.npmjs.com/package/prettier-package-json)
+[![CI](https://github.com/cameronhunter/prettier-package-json/actions/workflows/ci.yml/badge.svg)](https://github.com/cameronhunter/prettier-package-json/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/prettier-package-json.svg)](https://www.npmjs.com/package/prettier-package-json)
 
-`prettier-package-json` is a JSON formatter inspired by `prettier`. It removes all original styling and ensures that the outputted `package.json` conforms to a consistent style. By default it uses opinionated defaults but can be configured to your individual needs.
+`prettier-package-json` is a JSON formatter inspired by `prettier`. It removes
+all original styling and ensures that the outputted `package.json` conforms to a
+consistent style. By default it uses opinionated defaults but can be configured
+to your individual needs.
 
 ## Features
 
 ### Consistent key order
 
-Keys in `package.json` will be sorted in an [opinionated order](src/defaultOptions.ts) but may be configured to your own preferences.
+Keys in `package.json` will be sorted in an
+[opinionated order](src/defaultOptions.ts) but may be configured to your own
+preferences.
 
 Input:
 
@@ -36,7 +42,8 @@ Output:
 
 ### Sensibly sorted scripts
 
-The `scripts` field is sorted alphabetically but keeps `pre` and `post` scripts surrounding their named script.
+The `scripts` field is sorted alphabetically but keeps `pre` and `post` scripts
+surrounding their named script.
 
 Input:
 
@@ -72,8 +79,9 @@ Output:
 
 ### Expand/contract author, contributors, and maintainers
 
-The `author`, `contributors` and `maintainers` fields will be shortened to their string versions and sorted by name. Use
-the `--expand-users` option if you prefer user objects.
+The `author`, `contributors` and `maintainers` fields will be shortened to their
+string versions and sorted by name. Use the `--expand-users` option if you
+prefer user objects.
 
 Input:
 
@@ -103,8 +111,8 @@ Output:
 
 ### Filter and sort files field
 
-Some files are included or excluded automatically by `npm`, these are removed from the `files` field before sorting
-alphabetically.
+Some files are included or excluded automatically by `npm`, these are removed
+from the `files` field before sorting alphabetically.
 
 Input:
 
@@ -113,7 +121,13 @@ Input:
   "name": "prettier-package-json",
   "version": "1.0.1",
   "main": "src/index.js",
-  "files": ["src/index.js", "src", "CHANGELOG.md", "readme.md", "package-lock.json"]
+  "files": [
+    "src/index.js",
+    "src",
+    "CHANGELOG.md",
+    "readme.md",
+    "package-lock.json"
+  ]
 }
 ```
 
@@ -150,9 +164,11 @@ npm install [-g] prettier-package-json
 
 ### CLI
 
-Run `prettier-package-json` through the CLI with this script. Run it without any arguments to see the options.
+Run `prettier-package-json` through the CLI with this script. Run it without any
+arguments to see the options.
 
-To format a file in-place, use `--write`. You may want to consider committing your file before doing that, just in case.
+To format a file in-place, use `--write`. You may want to consider committing
+your file before doing that, just in case.
 
 ```sh
 prettier-package-json [opts] [filename]
@@ -166,7 +182,8 @@ prettier-package-json --write ./package.json
 
 #### Pre-commit hook for changed files
 
-You can use this with a pre-commit tool. This can re-format your files that are marked as "staged" via git add before you commit.
+You can use this with a pre-commit tool. This can re-format your files that are
+marked as "staged" via git add before you commit.
 
 ##### 1. [lint-staged](https://github.com/okonet/lint-staged)
 
@@ -189,11 +206,13 @@ and add this config to your `package.json`:
 }
 ```
 
-See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
+See https://github.com/okonet/lint-staged#configuration for more details about
+how you can configure lint-staged.
 
 ##### 2. bash script
 
-Alternately you can just save this script as `.git/hooks/pre-commit` and give it execute permission:
+Alternately you can just save this script as `.git/hooks/pre-commit` and give it
+execute permission:
 
 ```bash
 #!/bin/sh
@@ -212,7 +231,8 @@ exit 1
 
 ### API
 
-The API has two functions, exported as `format` and `check`. Usage is as follows:
+The API has two functions, exported as `format` and `check`. Usage is as
+follows:
 
 ```js
 import { format, check } from 'prettier-package-json';
@@ -223,39 +243,48 @@ format(json, options);
 check(json, options);
 ```
 
-`check` checks to see if the file has been formatted with `prettier-package-json` given those options and returns a Boolean.
-This is similar to the `--list-different` parameter in the CLI and is useful for running in CI scenarios.
+`check` checks to see if the file has been formatted with
+`prettier-package-json` given those options and returns a Boolean. This is
+similar to the `--list-different` parameter in the CLI and is useful for running
+in CI scenarios.
 
 ### CI
 
-For usage in CI scenarios, you can use the `--list-different` CLI flag. The command will list all invalid files and return
-with a proper default error code, so that in case of an error or invalid file the build pipeline automatically fails.
+For usage in CI scenarios, you can use the `--list-different` CLI flag. The
+command will list all invalid files and return with a proper default error code,
+so that in case of an error or invalid file the build pipeline automatically
+fails.
 
 These are the status codes:
 
 - `0`: all files valid, no error occured.
-- `1`: an error ocurred, for example a JSON parse error. See message on `stderr` for details.
+- `1`: an error ocurred, for example a JSON parse error. See message on `stderr`
+  for details.
 - `2`: not all files are valid.
 
 These exit codes are only set when in `--list-different` mode.
 
 ### Options
 
-`prettier-package-json` ships with a handful of customizable format options, usable in both the CLI, API, and configuration file.
+`prettier-package-json` ships with a handful of customizable format options,
+usable in both the CLI, API, and configuration file.
 
-| Option                                                              | Default                                                                                                         | CLI override                            | API override                  |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------- |
-| **Tab Width** - Specify the number of spaces per indentation-level. | `2`                                                                                                             | `--tab-width <int>`                     | `tabWidth: <int>`             |
-| **Tabs** - Indent lines with tabs instead of spaces.                | `false`                                                                                                         | `--use-tabs`                            | `useTabs: <bool>`             |
-| **Expand Users** - Expand author and contributors into objects.     | `false`                                                                                                         | `--expand-users`                        | `expandUsers: <bool>`         |
+| Option                                                              | Default                                      | CLI override                            | API override                  |
+| ------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------- | ----------------------------- |
+| **Tab Width** - Specify the number of spaces per indentation-level. | `2`                                          | `--tab-width <int>`                     | `tabWidth: <int>`             |
+| **Tabs** - Indent lines with tabs instead of spaces.                | `false`                                      | `--use-tabs`                            | `useTabs: <bool>`             |
+| **Expand Users** - Expand author and contributors into objects.     | `false`                                      | `--expand-users`                        | `expandUsers: <bool>`         |
 | **Key Order** - Specify the order of keys.                          | See [default options](src/defaultOptions.ts) | `--key-order <comma,separated,list...>` | `keyOrder: <array\|function>` |
 
-A configuration file will be searched for using [`cosmiconfig`](https://www.npmjs.com/package/cosmiconfig) rules:
+A configuration file will be searched for using
+[`cosmiconfig`](https://www.npmjs.com/package/cosmiconfig) rules:
 
 - `prettier-package-json` field in `package.json`.
 - `prettier-package-json` file (JSON or YAML), extentionless "rc" file.
-- `prettier-package-json` file with the extensions `.json`, `.yaml`, `.yml`, `.js`, or `.cjs`.
-- `prettier-package-json.config.js` or `prettier-package-json.config.cjs` CommonJS module.
+- `prettier-package-json` file with the extensions `.json`, `.yaml`, `.yml`,
+  `.js`, or `.cjs`.
+- `prettier-package-json.config.js` or `prettier-package-json.config.cjs`
+  CommonJS module.
 
 Configuration file may also be passed using the `--config` CLI parameter.
 

--- a/src/sort-contributors.ts
+++ b/src/sort-contributors.ts
@@ -3,6 +3,7 @@ import sortObject from 'sort-object-keys';
 import orderBy from 'sort-order';
 import { Author, Options, PackageJson } from './types';
 
+// prettier-ignore
 // Sort by a field in an object
 const field = <TType extends object>(name: keyof TType) => (...args: [TType, TType]) => {
   const [a, b] = args.map((obj) => obj[name]);

--- a/src/sort-files.ts
+++ b/src/sort-files.ts
@@ -10,8 +10,8 @@ import { PackageJson } from './types';
 
 type FilterFn<T> = (...args: T[]) => boolean;
 
-const not = <T>(filterFn: FilterFn<T>) => (arg: T) => !filterFn(arg);
-const or = <T>(...filterFns: FilterFn<T>[]) => (arg: T) => filterFns.some((fn) => fn(arg));
+const not = <T>(filterFn: FilterFn<T>) => (arg: T) => !filterFn(arg); // prettier-ignore
+const or = <T>(...filterFns: FilterFn<T>[]) => (arg: T) => filterFns.some((fn) => fn(arg)); // prettier-ignore
 
 const ALWAYS_INCLUDED = [
   /^package.json$/,
@@ -41,7 +41,7 @@ const ALWAYS_EXCLUDED = [
   '*.orig',
   'package-lock.json'
 ]
-  .map((glob) => (minimatch.filter(glob) as any) as FilterFn<string>)
+  .map((glob) => minimatch.filter(glob) as any as FilterFn<string>)
   .reduce((a, b) => or(a, b));
 
 export default function sortFiles(packageJson: PackageJson): { files?: PackageJson['files'] } {

--- a/tests/sort-files.test.ts
+++ b/tests/sort-files.test.ts
@@ -3,7 +3,7 @@ import { format } from '../src';
 test('It orders files in alphabetical order, directories first', () => {
   const json = {
     files: [
-      'IMPORTANT.md',
+      'IMPORTANT.md', //
       'lib/',
       'bin/'
     ]
@@ -15,7 +15,7 @@ test('It orders files in alphabetical order, directories first', () => {
 test('It orders files in alphabetical order, exclusions last', () => {
   const json = {
     files: [
-      '!lib/**/*.test.js',
+      '!lib/**/*.test.js', //
       'lib/',
       'bin/',
       '!bin/secret.text'
@@ -28,7 +28,7 @@ test('It orders files in alphabetical order, exclusions last', () => {
 test('It removes always excluded entries from files', () => {
   const json = {
     files: [
-      'bin/',
+      'bin/', //
       'lib/',
       'node_modules/',
       'package-lock.json'
@@ -41,7 +41,7 @@ test('It removes always excluded entries from files', () => {
 test('It removes always included entries from files', () => {
   const json = {
     files: [
-      'bin/',
+      'bin/', //
       'lib/',
       'package.json',
       'README.md'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,6 @@
 {
-  "include": [
-    "src",
-  ],
-  "exclude": [
-    "node_modules",
-    "build"
-  ],
+  "include": ["src"],
+  "exclude": ["node_modules", "build"],
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Motivation

I wanted to make things easier for contributors. 

## Summary

Most of the formatting in this project closely matches the formatting in the attached prettier config (which I graciously stole from [this file](https://github.com/cameronhunter/ink-markdown/blob/f97fb5cf1534d64c86e2ed3d412abacdb45ded6c/.prettierrc.js) from [another repo by](https://github.com/cameronhunter/ink-markdown) by @cameronhunter).

1. Added `prettierrc.js`
2. Reformatted each file (one commit at a time) subjectively adding `// prettier-ignore` & `//` comments to minimize changes.

### Shortlist of potentially most controversial changes

1. [Reformatting the README.md according to prettier](https://github.com/cameronhunter/prettier-package-json/commit/c9dcbde887461743527194fb2c40fc5d2d429b6a) is the largest change outside of adding `prettierrc.js`.  Arguably they could be added to the `.prettierignore` instead, but I noticed the original prettier file had a rule for .md in it so I kept the change.

2. [I added `__fixtures__` to `.prettierignore`.](https://github.com/cameronhunter/prettier-package-json/pull/43/commits/8676718e7df8d99a58b4cca8d14cc1c8ca451d87) I figured test data shouldn't be autoformatted.

## Additional note

### Tests passed

Steps
1. Installed. 
```
yarn 
```
2. Built.  
```
yarn build
```
3. Tested.  
```
yarn test
``` 

### On Opinions 

Code formatting is an opinionated thing. It's good to make these opinions explicit through prettier.

However, your preferred formatting may not be what I've done here. That's why I tried to put each change in its own file.

Additionally, there's always [this technique](https://medium.com/millennial-falcon-technology/reformatting-your-code-base-using-prettier-or-eslint-without-destroying-git-history-35052f3d853e) as well for preserving git history.