### PR TITLE
Fix dependencies order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import sortObject from 'sort-object-keys';
 import { defaultOptions } from './defaultOptions';
+import sortDependencies from './sort-dependencies';
 import sortUsers from './sort-contributors';
 import sortFiles from './sort-files';
 import sortScripts from './sort-scripts';
@@ -22,12 +23,12 @@ export function format(packageJson: PackageJson, opts?: Options) {
     ...sort('directories', packageJson),
     ...sortScripts(packageJson.scripts),
     ...sort('config', packageJson),
-    ...sort('optionalDependencies', packageJson),
-    ...sort('dependencies', packageJson),
-    ...sort('bundleDependencies', packageJson),
-    ...sort('bundledDependencies', packageJson),
-    ...sort('peerDependencies', packageJson),
-    ...sort('devDependencies', packageJson),
+    ...sortDependencies('optionalDependencies', packageJson),
+    ...sortDependencies('dependencies', packageJson),
+    ...sortDependencies('bundleDependencies', packageJson),
+    ...sortDependencies('bundledDependencies', packageJson),
+    ...sortDependencies('peerDependencies', packageJson),
+    ...sortDependencies('devDependencies', packageJson),
     ...sort('keywords', packageJson),
     ...sort('engines', packageJson),
     ...sort('os', packageJson),

--- a/src/sort-dependencies.ts
+++ b/src/sort-dependencies.ts
@@ -1,0 +1,20 @@
+import sortObject from 'sort-object-keys';
+import { PackageJson } from './types';
+
+function order(a: string, b: string) {
+  return a.localeCompare(b, 'en');
+}
+
+export default function sortDependencies<
+  TKey extends
+    | 'bundledDependencies'
+    | 'bundleDependencies'
+    | 'dependencies'
+    | 'devDependencies'
+    | 'optionalDependencies'
+    | 'peerDependencies'
+>(key: TKey, packageJson: PackageJson) {
+  const dependencies = packageJson[key];
+  const keys = Object.keys(dependencies || {}) as Array<keyof typeof dependencies & string>;
+  return keys.length === 0 ? {} : { [key]: sortObject(dependencies, keys.sort(order)) };
+}

--- a/tests/__snapshots__/key-order.test.ts.snap
+++ b/tests/__snapshots__/key-order.test.ts.snap
@@ -50,3 +50,14 @@ exports[`It orders unspecified keys alphabetically at the end 1`] = `
 }
 "
 `;
+
+exports[`It sorts dependencies lowercase-first (to match npm) 1`] = `
+"{
+  \\"dependencies\\": {
+    \\"a\\": \\"*\\",
+    \\"A\\": \\"*\\",
+    \\"b\\": \\"*\\"
+  }
+}
+"
+`;

--- a/tests/key-order.test.ts
+++ b/tests/key-order.test.ts
@@ -63,3 +63,15 @@ test('It orders scripts in alphabetical order, keeping pre and post scripts besi
 
   expect(format(json)).toMatchSnapshot();
 });
+
+test('It sorts dependencies lowercase-first (to match npm)', () => {
+  const json = {
+    dependencies: {
+      a: '*',
+      A: '*',
+      b: '*'
+    }
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});


### PR DESCRIPTION
When sorting *dependencies fields, use localeCompare-based function to
match the result to those of npm

Fixes #58