### PR TITLE
Adding `exports` key to be sorted above `main`

### DIFF
--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -28,7 +28,7 @@ export const defaultOptions: Options = {
     'exports',
     'main',
     'module',
-    'browser',    
+    'browser',
     'man',
     'preferGlobal',
     'bin',

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -25,10 +25,10 @@ export const defaultOptions: Options = {
     /**
      * Configuration
      */
+    'exports',
     'main',
     'module',
-    'browser',
-    'exports',
+    'browser',    
     'man',
     'preferGlobal',
     'bin',

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -28,6 +28,7 @@ export const defaultOptions: Options = {
     'main',
     'module',
     'browser',
+    'exports',
     'man',
     'preferGlobal',
     'bin',


### PR DESCRIPTION
Package.jsons now support `exports` maps, which will supersede `main` or `module` entries. Adding this to be sorted right above `main`. I chose to list it first, as node will prefer it over `main` and webpack will prefer it over `module` and typescript (when in resolution `nodenext`) will prefer it over `types` or `typings`.

