### PR TITLE
Improve scripts sorting

### DIFF
--- a/src/sort-scripts.ts
+++ b/src/sort-scripts.ts
@@ -4,39 +4,56 @@ import { PackageJson } from './types';
 
 const PRE_OR_POST_PREFIX = /^(pre|post)/;
 const NPM_RUN_ALL_SEPARATOR = /([:/])/;
+const NPM_BUILTIN_SCRIPTS = ['install', 'prepare', 'pack', 'publish', 'restart', 'start', 'stop', 'test', 'version', 'uninstall'];
 
-// Sort alphabetically by script name excluding pre/post prefixes
-function scriptName(...args: [string, string]): 1 | 0 | -1 {
-  const [a, b] = args.map((arg) => arg.replace(PRE_OR_POST_PREFIX, ''));
-  const aa = a.split(NPM_RUN_ALL_SEPARATOR);
-  const bb = b.split(NPM_RUN_ALL_SEPARATOR);
-  const al = aa.length;
-  const bl = bb.length;
-  for (let i = 0; i < al || i < bl; i++) {
-    if (aa[i] !== bb[i]) {
-      return aa[i] < bb[i] ? -1 : 1;
-    }
-  }
-  if (al !== bl) {
-    return al < bl ? -1 : 1;
-  }
-  return 0;
+function parseScriptName(scripts: PackageJson['scripts'], script: string): { prefix: '' | 'pre' | 'post'; name: string } {
+  if (script === 'prepublishOnly') return { prefix: 'pre', name: 'publish' };
+  const prefixMatch = PRE_OR_POST_PREFIX.exec(script);
+  const prefix = prefixMatch ? prefixMatch[0] as 'pre' | 'post' : '';
+  const name = script.slice(prefix.length);
+  if (scripts!.hasOwnProperty(name) || NPM_BUILTIN_SCRIPTS.includes(name)) return { prefix, name };
+  return { prefix: '', name: script };
 }
 
-// Sort by pre, script, post
-function prePostHooks(a: string, b: string): 1 | 0 | -1 {
-  if (a.startsWith('pre') || b.startsWith('post')) {
-    return -1;
-  } else if (a.startsWith('post') || b.startsWith('pre')) {
-    return 1;
-  } else {
+// Sort alphabetically by script name excluding pre/post prefixes
+function scriptName(scripts: PackageJson['scripts']) {
+  return function (a: string, b: string): 1 | 0 | -1 {
+    const an = parseScriptName(scripts, a).name;
+    const bn = parseScriptName(scripts, b).name;
+    const aa = an.split(NPM_RUN_ALL_SEPARATOR);
+    const bb = bn.split(NPM_RUN_ALL_SEPARATOR);
+    const al = aa.length;
+    const bl = bb.length;
+    for (let i = 0; i < al || i < bl; i++) {
+      if (aa[i] !== bb[i]) {
+        return aa[i] < bb[i] ? -1 : 1;
+      }
+    }
+    if (al !== bl) {
+      return al < bl ? -1 : 1;
+    }
     return 0;
   }
 }
 
-const order = orderBy(scriptName, prePostHooks);
+// Sort by pre, script, post
+function prePostHooks(scripts: PackageJson['scripts']) {
+  return function (a: string, b: string): 1 | 0 | -1 {
+    const av = parseScriptName(scripts, a);
+    const bv = parseScriptName(scripts, b);
+    if (av.prefix === 'pre' || bv.prefix === 'post') {
+      return -1;
+    } else if (av.prefix === 'post' || bv.prefix === 'pre') {
+      return 1;
+    } else if (av.name !== bv.name) {
+      return av.name < bv.name ? -1 : 1;
+    }
+    return 0;
+  }
+}
 
 export default function sortScripts(scripts: PackageJson['scripts']): { scripts?: PackageJson['scripts'] } {
   const keys = Object.keys(scripts || {}) as Array<keyof PackageJson['scripts']>;
+  const order = orderBy(scriptName(scripts), prePostHooks(scripts));
   return keys.length === 0 ? {} : { scripts: sortObject(scripts, keys.sort(order)) };
 }

--- a/src/sort-scripts.ts
+++ b/src/sort-scripts.ts
@@ -6,13 +6,13 @@ const PRE_OR_POST_PREFIX = /^(pre|post)/;
 const NPM_RUN_ALL_SEPARATOR = /([:/])/;
 const NPM_BUILTIN_SCRIPTS = ['install', 'prepare', 'pack', 'publish', 'restart', 'start', 'stop', 'test', 'version', 'uninstall'];
 
-function parseScriptName(scripts: PackageJson['scripts'], script: string): { prefix: '' | 'pre' | 'post'; name: string } {
+function parseScriptName(scripts: PackageJson['scripts'], script: string): { prefix: undefined | 'pre' | 'post'; name: string } {
   if (script === 'prepublishOnly') return { prefix: 'pre', name: 'publish' };
   const prefixMatch = PRE_OR_POST_PREFIX.exec(script);
-  const prefix = prefixMatch ? prefixMatch[0] as 'pre' | 'post' : '';
-  const name = script.slice(prefix.length);
+  const prefix = prefixMatch ? prefixMatch[0] as 'pre' | 'post' : undefined;
+  const name = prefix ? script.slice(prefix.length) : script;
   if (scripts!.hasOwnProperty(name) || NPM_BUILTIN_SCRIPTS.includes(name)) return { prefix, name };
-  return { prefix: '', name: script };
+  return { prefix: undefined, name: script };
 }
 
 // Sort alphabetically by script name excluding pre/post prefixes

--- a/src/sort-scripts.ts
+++ b/src/sort-scripts.ts
@@ -3,15 +3,24 @@ import orderBy from 'sort-order';
 import { PackageJson } from './types';
 
 const PRE_OR_POST_PREFIX = /^(pre|post)/;
+const NPM_RUN_ALL_SEPARATOR = /([:/])/;
 
 // Sort alphabetically by script name excluding pre/post prefixes
 function scriptName(...args: [string, string]): 1 | 0 | -1 {
   const [a, b] = args.map((arg) => arg.replace(PRE_OR_POST_PREFIX, ''));
-  if (a !== b) {
-    return a < b ? -1 : 1;
-  } else {
-    return 0;
+  const aa = a.split(NPM_RUN_ALL_SEPARATOR);
+  const bb = b.split(NPM_RUN_ALL_SEPARATOR);
+  const al = aa.length;
+  const bl = bb.length;
+  for (let i = 0; i < al || i < bl; i++) {
+    if (aa[i] !== bb[i]) {
+      return aa[i] < bb[i] ? -1 : 1;
+    }
   }
+  if (al !== bl) {
+    return al < bl ? -1 : 1;
+  }
+  return 0;
 }
 
 // Sort by pre, script, post

--- a/src/sort-scripts.ts
+++ b/src/sort-scripts.ts
@@ -6,31 +6,64 @@ const PRE_OR_POST_PREFIX = /^(pre|post)/;
 const NPM_RUN_ALL_SEPARATOR = /([:/])/;
 const NPM_BUILTIN_SCRIPTS = ['install', 'prepare', 'pack', 'publish', 'restart', 'start', 'stop', 'test', 'version', 'uninstall'];
 
-function parseScriptName(scripts: PackageJson['scripts'], script: string): { prefix: undefined | 'pre' | 'post'; name: string } {
-  if (script === 'prepublishOnly') return { prefix: 'pre', name: 'publish' };
-  const prefixMatch = PRE_OR_POST_PREFIX.exec(script);
+interface ParsedScriptName {
+  prefix?: 'pre' | 'post';
+
+  /**
+   * Base event name in the npm lifecycle. Often the string with prefix removed.
+   * For example, for an input `preprettier:lint`, the base would be `prettier:lint`.
+   */
+  base: string;
+
+
+  /**
+   * The full original name of the script
+   */
+  original: string;
+};
+
+function parseScriptName(scripts: PackageJson['scripts'], original: string): ParsedScriptName {
+  // prepublishOnly is a script whose base event is publish.
+  // cf. https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-publish
+  if (original === 'prepublishOnly') {
+    return { prefix: 'pre', base: 'publish', original };
+  }
+
+  const prefixMatch = PRE_OR_POST_PREFIX.exec(original);
   const prefix = prefixMatch ? prefixMatch[0] as 'pre' | 'post' : undefined;
-  const name = prefix ? script.slice(prefix.length) : script;
-  if (scripts!.hasOwnProperty(name) || NPM_BUILTIN_SCRIPTS.includes(name)) return { prefix, name };
-  return { prefix: undefined, name: script };
+  const base = prefix ? original.slice(prefix.length) : original;
+
+  if (scripts?.hasOwnProperty(base) || NPM_BUILTIN_SCRIPTS.includes(base)) {
+    return { prefix, base, original };
+  }
+
+  return { prefix: undefined, base: original, original };
 }
 
 // Sort alphabetically by script name excluding pre/post prefixes
 function scriptName(scripts: PackageJson['scripts']) {
   return function (a: string, b: string): 1 | 0 | -1 {
-    const an = parseScriptName(scripts, a).name;
-    const bn = parseScriptName(scripts, b).name;
-    const aa = an.split(NPM_RUN_ALL_SEPARATOR);
-    const bb = bn.split(NPM_RUN_ALL_SEPARATOR);
-    const al = aa.length;
-    const bl = bb.length;
-    for (let i = 0; i < al || i < bl; i++) {
-      if (aa[i] !== bb[i]) {
-        return aa[i] < bb[i] ? -1 : 1;
+    const aParsed = parseScriptName(scripts, a);
+    const bParsed = parseScriptName(scripts, b);
+
+    // For example, for an input name `prettier:lint`, the segments would be `['prettier', ':', 'lint']`.
+    // The segments contains separators. There are two types of separators, to determine their order.
+    const aSegments = aParsed.base.split(NPM_RUN_ALL_SEPARATOR);
+    const bSegments = bParsed.base.split(NPM_RUN_ALL_SEPARATOR);
+
+    const aLength = aSegments.length;
+    const bLength = bSegments.length;
+
+    // Compare each segment, and when the strings are different, return 1 or -1 in alphabetical order.
+    for (let i = 0; i < Math.min(aLength, bLength); i++) {
+      if (aSegments[i] !== bSegments[i]) {
+        return aSegments[i] < bSegments[i] ? -1 : 1;
       }
     }
-    if (al !== bl) {
-      return al < bl ? -1 : 1;
+
+    // Compare segments length, return 1 or -1 in ascending order of length.
+    if (aLength !== bLength) {
+      return aLength < bLength ? -1 : 1;
     }
     return 0;
   }
@@ -39,14 +72,14 @@ function scriptName(scripts: PackageJson['scripts']) {
 // Sort by pre, script, post
 function prePostHooks(scripts: PackageJson['scripts']) {
   return function (a: string, b: string): 1 | 0 | -1 {
-    const av = parseScriptName(scripts, a);
-    const bv = parseScriptName(scripts, b);
-    if (av.prefix === 'pre' || bv.prefix === 'post') {
+    const aParsed = parseScriptName(scripts, a);
+    const bParsed = parseScriptName(scripts, b);
+    if (aParsed.prefix === 'pre' || bParsed.prefix === 'post') {
       return -1;
-    } else if (av.prefix === 'post' || bv.prefix === 'pre') {
+    } else if (aParsed.prefix === 'post' || bParsed.prefix === 'pre') {
       return 1;
-    } else if (av.name !== bv.name) {
-      return av.name < bv.name ? -1 : 1;
+    } else if (aParsed.base !== bParsed.base) {
+      return aParsed.base < bParsed.base ? -1 : 1;
     }
     return 0;
   }

--- a/tests/__snapshots__/script-order.test.ts.snap
+++ b/tests/__snapshots__/script-order.test.ts.snap
@@ -13,6 +13,29 @@ exports[`It orders scripts in alphabetical order, keeping pre and post scripts b
 "
 `;
 
+exports[`It orders scripts that base script does not exist in alphabetical order 1`] = `
+"{
+  \\"scripts\\": {
+    \\"preinstall\\": \\"preinstall\\",
+    \\"postinstall\\": \\"postinstall\\",
+    \\"lint\\": \\"run-s lint:* *:lint\\",
+    \\"lint:eslint\\": \\"lint:eslint\\",
+    \\"lint-fix\\": \\"run-s lint-fix:* *:lint-fix\\",
+    \\"lint-fix:eslint\\": \\"lint-fix:eslint\\",
+    \\"prepostcss\\": \\"postpostcss\\",
+    \\"postcss\\": \\"postcss\\",
+    \\"postpostcss\\": \\"postpostcss\\",
+    \\"preprepare\\": \\"preprepare\\",
+    \\"prepare\\": \\"prepare\\",
+    \\"postprepare\\": \\"postprepare\\",
+    \\"prettier:lint\\": \\"prettier:lint\\",
+    \\"prettier:lint-fix\\": \\"prettier:lint-fix\\",
+    \\"prepublishOnly\\": \\"prepublishOnly\\"
+  }
+}
+"
+`;
+
 exports[`It orders scripts with separators in alphabetical order 1`] = `
 "{
   \\"scripts\\": {

--- a/tests/__snapshots__/script-order.test.ts.snap
+++ b/tests/__snapshots__/script-order.test.ts.snap
@@ -12,3 +12,19 @@ exports[`It orders scripts in alphabetical order, keeping pre and post scripts b
 }
 "
 `;
+
+exports[`It orders scripts with separators in alphabetical order 1`] = `
+"{
+  \\"scripts\\": {
+    \\"dev\\": \\"dev\\",
+    \\"lint\\": \\"lint\\",
+    \\"lint:bar\\": \\"lint:bar\\",
+    \\"lint:foo\\": \\"lint:foo\\",
+    \\"lint-fix\\": \\"lint-fix\\",
+    \\"lint-fix:baz\\": \\"lint-fix:baz\\",
+    \\"lint-fix:qux\\": \\"lint-fix:qux\\",
+    \\"test\\": \\"test\\"
+  }
+}
+"
+`;

--- a/tests/script-order.test.ts
+++ b/tests/script-order.test.ts
@@ -13,3 +13,20 @@ test('It orders scripts in alphabetical order, keeping pre and post scripts besi
 
   expect(format(json)).toMatchSnapshot();
 });
+
+test('It orders scripts with separators in alphabetical order', () => {
+  const json = {
+    scripts: {
+      dev: 'dev',
+      test: 'test',
+      lint: 'lint',
+      'lint:foo': 'lint:foo',
+      'lint:bar': 'lint:bar',
+      'lint-fix': 'lint-fix',
+      'lint-fix:baz': 'lint-fix:baz',
+      'lint-fix:qux': 'lint-fix:qux'
+    }
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});

--- a/tests/script-order.test.ts
+++ b/tests/script-order.test.ts
@@ -30,3 +30,27 @@ test('It orders scripts with separators in alphabetical order', () => {
 
   expect(format(json)).toMatchSnapshot();
 });
+
+test('It orders scripts that base script does not exist in alphabetical order', () => {
+  const json = {
+    scripts: {
+      lint: 'run-s lint:* *:lint',
+      'lint:eslint': 'lint:eslint',
+      'prettier:lint': 'prettier:lint',
+      'lint-fix': 'run-s lint-fix:* *:lint-fix',
+      'lint-fix:eslint': 'lint-fix:eslint',
+      'prettier:lint-fix': 'prettier:lint-fix',
+      postcss: 'postcss',
+      prepostcss: 'postpostcss',
+      postpostcss: 'postpostcss',
+      prepublishOnly: 'prepublishOnly',
+      prepare: 'prepare',
+      preprepare: 'preprepare',
+      postprepare: 'postprepare',
+      preinstall: 'preinstall',
+      postinstall: 'postinstall'
+    },
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});


### PR DESCRIPTION
I implemented sorting of script names containing separates mentioned in #65. 

When I writing the test, I noticed that the order of scripts containing prefixes (e.g., prettier, postcss) was incorrect, so I fixed it in the second commit.