### PR TITLE
Fix sorting differences with npm deps

### DIFF
--- a/src/sort-dependencies.ts
+++ b/src/sort-dependencies.ts
@@ -1,10 +1,6 @@
 import sortObject from 'sort-object-keys';
 import { PackageJson } from './types';
 
-function order(a: string, b: string) {
-  return a.localeCompare(b, 'en');
-}
-
 export default function sortDependencies<
   TKey extends
     | 'bundledDependencies'
@@ -16,5 +12,5 @@ export default function sortDependencies<
 >(key: TKey, packageJson: PackageJson) {
   const dependencies = packageJson[key];
   const keys = Object.keys(dependencies || {}) as Array<keyof typeof dependencies & string>;
-  return keys.length === 0 ? {} : { [key]: sortObject(dependencies, keys.sort(order)) };
+  return keys.length === 0 ? {} : { [key]: sortObject(dependencies, keys.sort()) };
 }

--- a/tests/__snapshots__/sort-dependencies.test.ts.snap
+++ b/tests/__snapshots__/sort-dependencies.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`It orders dependencies in alphabetical order 1`] = `
+"{
+  \\"dependencies\\": {
+    \\"a\\": \\"1\\",
+    \\"foo-bar\\": \\"2\\",
+    \\"foo_bar\\": \\"3\\",
+    \\"g\\": \\"4\\"
+  }
+}
+"
+`;

--- a/tests/sort-dependencies.test.ts
+++ b/tests/sort-dependencies.test.ts
@@ -1,0 +1,14 @@
+import { format } from '../src';
+
+test('It orders dependencies in alphabetical order', () => {
+  const json = {
+    dependencies: {
+        foo_bar: "3",
+        g: "4",
+        a: "1",
+        "foo-bar": "2", // the "-" should be before the "_" to match `npm` sorting
+    }
+  };
+
+  expect(format(json)).toMatchSnapshot();
+});


### PR DESCRIPTION
Resolves #54 

Fixes the sorting of packages to match what NPM does by using the normal "sort()" function on an array of strings instead of using a locale comparator.

Tests have been added for the dependency sorting functionality now.